### PR TITLE
再デプロイ後の古いチャンク参照による 404 を自動リロードで対処

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,11 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "@/app";
 
+// 再デプロイ後に古いチャンクファイルが 404 になった場合、自動でリロードして新しいファイルを読み込む
+window.addEventListener("vite:preloadError", () => {
+  window.location.reload();
+});
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
Vite のコード分割によりチャンクファイルはハッシュ付きで生成される。
再デプロイ後にブラウザが旧ハッシュのファイルを読もうとすると 404 になるため、
vite:preloadError イベントを検知してページを自動リロードするよう修正した。

https://claude.ai/code/session_01YN1GTBLfHtf7xA98xMPNAN